### PR TITLE
perhaps WatchTree should return all nodes.

### DIFF
--- a/etcdv3.go
+++ b/etcdv3.go
@@ -195,23 +195,12 @@ func (s *EtcdV3) WatchTree(directory string, stopCh <-chan struct{}) (<-chan []*
 			select {
 			case <-s.done:
 				return
-			case wresp := <-rch:
-				if len(wresp.Events) > 0 {
-					var pairs []*store.KVPair
-					for _, event := range wresp.Events {
-						pairs = append(pairs, &store.KVPair{
-							Key:       string(event.Kv.Key),
-							Value:     event.Kv.Value,
-							LastIndex: uint64(event.Kv.Version),
-						})
-					}
-					watchCh <- pairs
+			case <-rch:
+				list, err := s.List(directory)
+				if err != nil {
+				        return
 				}
-
-				// error
-				if wresp.Err() != nil {
-					return
-				}
+				watchCh <- list
 			}
 		}
 	}()


### PR DESCRIPTION
WatchTree should return all nodes not just the changes.
https://github.com/docker/libkv/blob/458977154600b9f23984d9f4b82e79570b5ae12b/store/etcd/etcd.go#L311